### PR TITLE
Typo in Query String Parameter Name

### DIFF
--- a/HubSpot.NET/Api/CustomObject/HubSpotCustomObjectApi.cs
+++ b/HubSpot.NET/Api/CustomObject/HubSpotCustomObjectApi.cs
@@ -175,7 +175,7 @@ public class HubSpotCustomObjectApi : IHubSpotCustomObjectApi
             .SetQueryParam("count", opts.Limit);
 
         if (opts.PropertiesToInclude.Any())
-            path = path.SetQueryParam("property", opts.PropertiesToInclude);
+            path = path.SetQueryParam("properties", opts.PropertiesToInclude);
 
         if (opts.Offset.HasValue)
             path = path.SetQueryParam("vidOffset", opts.Offset);


### PR DESCRIPTION
Bugfix.  

When listing additional properties on custom objects, the expected query string parameter name is "properties" not "property"

I've tested this change locally and the properties I was requesting showed up after the change.  The documentation from HubSpot is here: https://developers.hubspot.com/docs/api/crm/crm-custom-objects